### PR TITLE
[FIX] 차량 연식 카테고리 조회 carName 필터 수정

### DIFF
--- a/src/main/java/com/tarbonicar/backend/api/category/controller/CategoryController.java
+++ b/src/main/java/com/tarbonicar/backend/api/category/controller/CategoryController.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @Tag(name = "Category", description = "카테고리 관련 API입니다.")
@@ -76,9 +77,9 @@ public class CategoryController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "차량 연식 카테고리 조회 성공")})
     @GetMapping("/search/home/carage")
-    public ResponseEntity<ApiResponse<List<CarAgeResponseDTO>>> getHomeCarAgeCategory(@RequestParam String carType, @RequestParam String carName) {
+    public ResponseEntity<ApiResponse<List<CarAgeResponseDTO>>> getHomeCarAgeCategory(@RequestParam String carType, @RequestParam List<String> carName) {
 
-        List<CarAgeResponseDTO> ages = categoryService.getHomeCarAgeCategory(carType.trim(), carName.trim());
+        List<CarAgeResponseDTO> ages = categoryService.getHomeCarAgeCategory(carType.trim(), carName.stream().map(String::trim).collect(Collectors.toList()));
         return ApiResponse.success(SuccessStatus.SEND_CARNAME_CATEGORY_SUCCESS, ages);
     }
 

--- a/src/main/java/com/tarbonicar/backend/api/category/repository/CarAgeRepository.java
+++ b/src/main/java/com/tarbonicar/backend/api/category/repository/CarAgeRepository.java
@@ -7,5 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface CarAgeRepository extends JpaRepository<CarAge, Long> {
+
     List<CarAge> findAllByCarName(CarName carName);
+    List<CarAge> findAllByCarNameOrderByCarAgeDesc(CarName carName);
+    boolean existsByCarNameAndCarAge(CarName carName, int carAge);
 }

--- a/src/main/java/com/tarbonicar/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/tarbonicar/backend/common/response/ErrorStatus.java
@@ -18,6 +18,7 @@ public enum ErrorStatus {
     PASSWORD_MISMATCH_EXCEPTION(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     MISSING_UPLOAD_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "업로드할 이미지가 없습니다."),
     THIS_MEMBER_IS_NOT_WRITER_EXCEPTION(HttpStatus.BAD_REQUEST,"게시글 작성자가 아닙니다."),
+    ALREADY_ADD_CARAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 등록된 차량 연식 입니다."),
 
     /**
      * 401 UNAUTHORIZED


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #24

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 차량 연식 카테고리 조회 carName 필터를 여러개로 받아서 처리할 수 있도록 수정하였습니다.
- 차량 연식 조회 시 연식 최신순으로 반환하도록 수정하였습니다.
- 카테고리 등록 시 차량 연식이 중복이 되는 케이스 예외처리 등록하였습니다.