### PR TITLE
[FEAT] 카카오 로그인 기능 구현

### DIFF
--- a/src/main/java/com/tarbonicar/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/tarbonicar/backend/api/member/controller/MemberController.java
@@ -2,7 +2,10 @@ package com.tarbonicar.backend.api.member.controller;
 
 import com.tarbonicar.backend.api.member.dto.MemberSignupRequestDto;
 import com.tarbonicar.backend.api.member.service.MemberService;
+import com.tarbonicar.backend.api.member.service.OAuthService;
+import com.tarbonicar.backend.common.exception.BadRequestException;
 import com.tarbonicar.backend.common.response.ApiResponse;
+import com.tarbonicar.backend.common.response.ErrorStatus;
 import com.tarbonicar.backend.common.response.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -10,10 +13,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
+    private final OAuthService oAuthService;
 
     @Operation(
             summary = "이메일 회원가입 API", description = "회원정보를 받아 사용자를 등록합니다.")
@@ -32,6 +35,24 @@ public class MemberController {
     public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody MemberSignupRequestDto requestDto) {
         memberService.signup(requestDto);
         return ApiResponse.success_only(SuccessStatus.SEND_REGISTER_SUCCESS);
+    }
+
+    // 카카오 인가코드로 액세스토큰 발급
+    @GetMapping("/accesstoken")
+    public ResponseEntity<ApiResponse<Map<String, String>>> getAccessToken(@RequestParam("code") String code) {
+        String token = oAuthService.getKakaoAccessToken(code);
+        return ApiResponse.success(SuccessStatus.SEND_KAKAO_ACCESS_TOKEN_SUCCESS, Map.of("accessToken", token));
+    }
+
+    // 카카오 액세스토큰으로 로그인
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody Map<String, String> body) {
+        String token = body.get("accessToken");
+        if (token == null || token.isBlank()) {
+            throw new BadRequestException(ErrorStatus.KAKAO_LOGIN_FAILED.getMessage());
+        }
+        memberService.kakaoLogin(token);
+        return ApiResponse.success_only(SuccessStatus.SEND_KAKAO_LOGIN_SUCCESS);
     }
 }
 

--- a/src/main/java/com/tarbonicar/backend/api/member/controller/MemberController.java
+++ b/src/main/java/com/tarbonicar/backend/api/member/controller/MemberController.java
@@ -3,9 +3,7 @@ package com.tarbonicar.backend.api.member.controller;
 import com.tarbonicar.backend.api.member.dto.MemberSignupRequestDto;
 import com.tarbonicar.backend.api.member.service.MemberService;
 import com.tarbonicar.backend.api.member.service.OAuthService;
-import com.tarbonicar.backend.common.exception.BadRequestException;
 import com.tarbonicar.backend.common.response.ApiResponse;
-import com.tarbonicar.backend.common.response.ErrorStatus;
 import com.tarbonicar.backend.common.response.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -38,19 +36,24 @@ public class MemberController {
     }
 
     // 카카오 인가코드로 액세스토큰 발급
-    @GetMapping("/accesstoken")
+    @Operation(summary = "카카오 AccessToken 발급 API", description = "카카오 인가 코드를 사용하여 AccessToken을 발급받습니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "AccessToken 발급 성공")
+    })
+    @GetMapping("/kakao-accesstoken")
     public ResponseEntity<ApiResponse<Map<String, String>>> getAccessToken(@RequestParam("code") String code) {
         String token = oAuthService.getKakaoAccessToken(code);
         return ApiResponse.success(SuccessStatus.SEND_KAKAO_ACCESS_TOKEN_SUCCESS, Map.of("accessToken", token));
     }
 
     // 카카오 액세스토큰으로 로그인
-    @PostMapping("/login")
+    @Operation(summary = "카카오 로그인 API", description = "카카오 AccessToken으로 사용자 정보를 조회하고 회원가입 또는 로그인을 처리합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카카오 로그인 성공")
+    })
+    @PostMapping("/kakao-login")
     public ResponseEntity<?> login(@RequestBody Map<String, String> body) {
         String token = body.get("accessToken");
-        if (token == null || token.isBlank()) {
-            throw new BadRequestException(ErrorStatus.KAKAO_LOGIN_FAILED.getMessage());
-        }
         memberService.kakaoLogin(token);
         return ApiResponse.success_only(SuccessStatus.SEND_KAKAO_LOGIN_SUCCESS);
     }

--- a/src/main/java/com/tarbonicar/backend/api/member/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/tarbonicar/backend/api/member/dto/KakaoUserInfoDto.java
@@ -1,0 +1,15 @@
+package com.tarbonicar.backend.api.member.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoUserInfoDto {
+    private String id;
+    private String email;
+    private String nickname;
+    private String profileImage;
+}

--- a/src/main/java/com/tarbonicar/backend/api/member/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/tarbonicar/backend/api/member/dto/KakaoUserInfoDto.java
@@ -3,7 +3,6 @@ package com.tarbonicar.backend.api.member.dto;
 import lombok.*;
 
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/tarbonicar/backend/api/member/dto/MemberSignupRequestDto.java
+++ b/src/main/java/com/tarbonicar/backend/api/member/dto/MemberSignupRequestDto.java
@@ -41,7 +41,7 @@ public class MemberSignupRequestDto {
                 .password(encodedPassword)
                 .nickname(nickname)
                 .profileImage(profileImageUrl)
-                .socialType(null)
+                .socialType("NORMAL")
                 .socialId(null)
                 .build();
     }

--- a/src/main/java/com/tarbonicar/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/tarbonicar/backend/api/member/service/MemberService.java
@@ -45,6 +45,11 @@ public class MemberService {
     @Transactional
     public Map<String, Object> kakaoLogin(String kakaoAccessToken) {
 
+        // 카카오 액세스 토큰이 null이거나 빈 문자열일 경우 예외 처리
+        if (kakaoAccessToken == null || kakaoAccessToken.isBlank()) {
+            throw new BadRequestException(ErrorStatus.KAKAO_LOGIN_FAILED.getMessage());
+        }
+
         // 카카오 액세스 토큰을 사용해서 사용자 정보 가져오기
         KakaoUserInfoDto userInfo = oAuthService.getKakaoUserInfo(kakaoAccessToken);
 

--- a/src/main/java/com/tarbonicar/backend/api/member/service/MemberService.java
+++ b/src/main/java/com/tarbonicar/backend/api/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.tarbonicar.backend.api.member.service;
 
+import com.tarbonicar.backend.api.member.dto.KakaoUserInfoDto;
 import com.tarbonicar.backend.api.member.dto.MemberSignupRequestDto;
 import com.tarbonicar.backend.api.member.entity.Member;
 import com.tarbonicar.backend.api.member.repository.MemberRepository;
@@ -9,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +19,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final OAuthService oAuthService;
 
     // 이메일 회원가입 메서드
     @Transactional
@@ -36,5 +40,38 @@ public class MemberService {
 
         Member member = requestDto.toEntity(encodedPassword, null);
         memberRepository.save(member);
+    }
+
+    @Transactional
+    public Map<String, Object> kakaoLogin(String kakaoAccessToken) {
+
+        // 카카오 액세스 토큰을 사용해서 사용자 정보 가져오기
+        KakaoUserInfoDto userInfo = oAuthService.getKakaoUserInfo(kakaoAccessToken);
+
+        // 사용자 정보 저장
+        Member member = memberRepository.findBySocialId(userInfo.getId())
+                .orElseGet(() -> kakaoRegister(userInfo));  // 없으면 회원가입
+
+        // 로그인 시 응답 데이터 구성
+        Map<String, Object> result = new HashMap<>();
+        result.put("nickname", member.getNickname());
+        result.put("email", member.getEmail());
+        result.put("profileImage", member.getProfileImage());
+        result.put("socialId", member.getSocialId());
+
+        return result;
+    }
+
+    // 새 유저 회원가입 처리
+    private Member kakaoRegister(KakaoUserInfoDto dto) {
+        Member member = Member.builder()
+                .socialId(dto.getId())
+                .email("kakao_" + dto.getId() + "@social.com")
+                .nickname(dto.getNickname())
+                .profileImage(dto.getProfileImage())
+                .socialType("KAKAO")
+                .build();
+
+        return memberRepository.save(member);
     }
 }

--- a/src/main/java/com/tarbonicar/backend/api/member/service/OAuthService.java
+++ b/src/main/java/com/tarbonicar/backend/api/member/service/OAuthService.java
@@ -32,11 +32,15 @@ public class OAuthService {
 
     // 인가 코드로 액세스 토큰 요청
     public String getKakaoAccessToken(String code) {
+
+        // 카카오 토큰 요청을 위한 URL 설정
         String tokenUri = "https://kauth.kakao.com/oauth/token";
 
+        // HttpHeaders 설정
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
+        // 파라미터 설정
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", clientId);
@@ -44,13 +48,16 @@ public class OAuthService {
         body.add("redirect_uri", redirectUri);
         body.add("code", code);
 
+        // HTTP 요청 생성 및 전송
         HttpEntity<?> request = new HttpEntity<>(body, headers);
         ResponseEntity<String> response = restTemplate.postForEntity(tokenUri, request, String.class);
 
+        // 예외처리
         if (!response.getStatusCode().is2xxSuccessful()) {
             throw new BadRequestException(ErrorStatus.KAKAO_TOKEN_REQUEST_FAILED.getMessage());
         }
 
+        // 액세스 토큰 추출
         try {
             Map<String, Object> responseBody = new ObjectMapper().readValue(response.getBody(), Map.class);
             return responseBody.get("access_token").toString();
@@ -61,18 +68,24 @@ public class OAuthService {
 
     // 액세스 토큰으로 사용자 정보 요청
     public KakaoUserInfoDto getKakaoUserInfo(String accessToken) {
+
+        // 사용자 정보 요청 URL
         String userInfoUri = "https://kapi.kakao.com/v2/user/me";
 
+        // HttpHeaders 설정
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(accessToken);
 
+        // HTTP 요청 생성 및 전송
         HttpEntity<?> request = new HttpEntity<>(headers);
         ResponseEntity<String> response = restTemplate.exchange(userInfoUri, HttpMethod.GET, request, String.class);
 
+        // 예외처리
         if (!response.getStatusCode().is2xxSuccessful()) {
             throw new BadRequestException(ErrorStatus.KAKAO_USERINFO_REQUEST_FAILED.getMessage());
         }
 
+        // 사용자 정보 추출
         try {
             Map<String, Object> result = new ObjectMapper().readValue(response.getBody(), Map.class);
 

--- a/src/main/java/com/tarbonicar/backend/api/member/service/OAuthService.java
+++ b/src/main/java/com/tarbonicar/backend/api/member/service/OAuthService.java
@@ -1,0 +1,94 @@
+package com.tarbonicar.backend.api.member.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tarbonicar.backend.api.member.dto.KakaoUserInfoDto;
+import com.tarbonicar.backend.common.exception.BadRequestException;
+import com.tarbonicar.backend.common.exception.InternalServerException;
+import com.tarbonicar.backend.common.response.ErrorStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+public class OAuthService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String clientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectUri;
+
+    // 인가 코드로 액세스 토큰 요청
+    public String getKakaoAccessToken(String code) {
+        String tokenUri = "https://kauth.kakao.com/oauth/token";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        HttpEntity<?> request = new HttpEntity<>(body, headers);
+        ResponseEntity<String> response = restTemplate.postForEntity(tokenUri, request, String.class);
+
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new BadRequestException(ErrorStatus.KAKAO_TOKEN_REQUEST_FAILED.getMessage());
+        }
+
+        try {
+            Map<String, Object> responseBody = new ObjectMapper().readValue(response.getBody(), Map.class);
+            return responseBody.get("access_token").toString();
+        } catch (Exception e) {
+            throw new InternalServerException(ErrorStatus.INTERNAL_TOKEN_PARSING_FAILED.getMessage());
+        }
+    }
+
+    // 액세스 토큰으로 사용자 정보 요청
+    public KakaoUserInfoDto getKakaoUserInfo(String accessToken) {
+        String userInfoUri = "https://kapi.kakao.com/v2/user/me";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<?> request = new HttpEntity<>(headers);
+        ResponseEntity<String> response = restTemplate.exchange(userInfoUri, HttpMethod.GET, request, String.class);
+
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new BadRequestException(ErrorStatus.KAKAO_USERINFO_REQUEST_FAILED.getMessage());
+        }
+
+        try {
+            Map<String, Object> result = new ObjectMapper().readValue(response.getBody(), Map.class);
+
+            // 프로필 정보 추출
+            Map<String, Object> kakaoAccount = (Map<String, Object>) result.get("kakao_account");
+            Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+            return KakaoUserInfoDto.builder()
+                    .id(result.get("id").toString())
+                    .email("kakao_" + result.get("id").toString() + "@social.com")
+                    .nickname((String) profile.get("nickname"))
+                    .profileImage((String) profile.get("profile_image_url"))
+                    .build();
+        } catch (Exception e) {
+            throw new InternalServerException(ErrorStatus.INTERNAL_USERINFO_PARSING_FAILED.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/tarbonicar/backend/common/config/sescurity/SecurityConfig.java
+++ b/src/main/java/com/tarbonicar/backend/common/config/sescurity/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용 안함 (JWT 대비용)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/swagger-ui.html", "/webjars/**", "/api-doc").permitAll() // H2, Swagger 인증 허용
-                        .requestMatchers("/api/v1/member/signup", "/api/v1/member/accesstoken", "/api/v1/member/login", "/api/v1/member/token-reissue").permitAll() // 회원가입 인증 허용
+                        .requestMatchers("/api/v1/member/signup", "/api/v1/member/kakao-accesstoken", "/api/v1/member/kakao-login", "/api/v1/member/token-reissue").permitAll() // 회원가입 인증 허용
                         .requestMatchers("/api/v1/category", "/api/v1/category/search/**", "/api/v1/category/**").permitAll() // 카테고리 관련 인증 허용
                         .requestMatchers("/api/v1/s3/upload-image", "/api/v1/article", "/api/v1/article/**", "/api/v1/article/list").permitAll() // 이미지 업로드, 게시글 관련 인증 허용 - 추후 허용 해제 예정
                         .anyRequest().authenticated()

--- a/src/main/java/com/tarbonicar/backend/common/config/sescurity/SecurityConfig.java
+++ b/src/main/java/com/tarbonicar/backend/common/config/sescurity/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용 안함 (JWT 대비용)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/swagger-ui.html", "/webjars/**", "/api-doc").permitAll() // H2, Swagger 인증 허용
-                        .requestMatchers("/api/v1/member/signup").permitAll() // 회원가입 인증 허용
+                        .requestMatchers("/api/v1/member/signup", "/api/v1/member/accesstoken", "/api/v1/member/login", "/api/v1/member/token-reissue").permitAll() // 회원가입 인증 허용
                         .requestMatchers("/api/v1/category", "/api/v1/category/search/**", "/api/v1/category/**").permitAll() // 카테고리 관련 인증 허용
                         .requestMatchers("/api/v1/s3/upload-image", "/api/v1/article", "/api/v1/article/**").permitAll() // 이미지 업로드, 게시글 관련 인증 허용 - 추후 허용 해제 예정
                         .anyRequest().authenticated()

--- a/src/main/java/com/tarbonicar/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/tarbonicar/backend/common/response/ErrorStatus.java
@@ -16,6 +16,11 @@ public enum ErrorStatus {
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 값이 입력되지 않았습니다."),
     ALREADY_EMAIL_EXIST_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
     PASSWORD_MISMATCH_EXCEPTION(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    KAKAO_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "카카오 로그인에 실패했습니다."),
+    KAKAO_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "카카오 토큰 요청에 실패했습니다."),
+    INTERNAL_TOKEN_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 토큰 응답 파싱 실패"),
+    KAKAO_USERINFO_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "카카오 사용자 정보 요청에 실패했습니다."),
+    INTERNAL_USERINFO_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 사용자 정보 파싱에 실패했습니다."),
     MISSING_UPLOAD_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "업로드할 이미지가 없습니다."),
     THIS_MEMBER_IS_NOT_WRITER_EXCEPTION(HttpStatus.BAD_REQUEST,"게시글 작성자가 아닙니다."),
 

--- a/src/main/java/com/tarbonicar/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/tarbonicar/backend/common/response/SuccessStatus.java
@@ -24,6 +24,8 @@ public enum SuccessStatus {
     SEND_ARTICLE_DETAIL_SUCCESS(HttpStatus.OK,"게시글 상세 조회 성공"),
     MODIFY_ARTICLE_SUCCESS(HttpStatus.OK,"게시글 수정 성공"),
     DELETE_ARTICLE_SUCCESS(HttpStatus.OK,"게시글 삭제 성공"),
+    SEND_KAKAO_LOGIN_SUCCESS(HttpStatus.OK, "카카오 로그인 성공"),
+    SEND_KAKAO_ACCESS_TOKEN_SUCCESS(HttpStatus.OK, "카카오 액세스 토큰 발급 성공"),
 
     /**
      * 201


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #17 

## 📝 Summary
- 카카오 로그인 기능 구현
- 인가 코드로 AccessToken 발급
- 사용자 정보 조회 후 DB 저장 및 로그인 처리

## 🙏 Question & PR point
- JWT 발급은 나중에 

## 📬 Reference
지피티