### PR TITLE
[FIX] 게시글 삭제 시 연관관계 데이터 삭제

### DIFF
--- a/src/main/java/com/tarbonicar/backend/api/article/repository/ArticleLikeRepository.java
+++ b/src/main/java/com/tarbonicar/backend/api/article/repository/ArticleLikeRepository.java
@@ -2,6 +2,9 @@ package com.tarbonicar.backend.api.article.repository;
 
 import com.tarbonicar.backend.api.article.entity.ArticleLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,4 +15,8 @@ public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> 
 
     // 좋아요 상태 체크
     Optional<ArticleLike> findByArticle_IdAndMember_Id(Long articleId, Long memberId);
+
+    @Modifying
+    @Query("DELETE FROM ArticleLike al WHERE al.article.id = :articleId")
+    void deleteByArticleId(@Param("articleId") Long articleId);
 }

--- a/src/main/java/com/tarbonicar/backend/api/article/service/ArticleService.java
+++ b/src/main/java/com/tarbonicar/backend/api/article/service/ArticleService.java
@@ -207,6 +207,13 @@ public class ArticleService {
             throw new BadRequestException(ErrorStatus.THIS_MEMBER_IS_NOT_WRITER_EXCEPTION.getMessage());
         }
 
+        // 좋아요 삭제
+        articleLikeRepository.deleteByArticleId(articleId);
+
+        // 댓글 삭제
+        commentRepository.deleteByArticleId(articleId);
+
+        // 게시글 삭제
         articleRepository.delete(article);
     }
 

--- a/src/main/java/com/tarbonicar/backend/api/comment/repository/CommentRepository.java
+++ b/src/main/java/com/tarbonicar/backend/api/comment/repository/CommentRepository.java
@@ -2,6 +2,9 @@ package com.tarbonicar.backend.api.comment.repository;
 
 import com.tarbonicar.backend.api.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -12,4 +15,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     // 댓글 개수 조회
     long countByArticle_Id(Long articleId);
+
+    @Modifying
+    @Query("DELETE FROM Comment c WHERE c.article.id = :articleId")
+    void deleteByArticleId(@Param("articleId") Long articleId);
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #45

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 게시글 삭제 시 관련된 좋아요, 댓글을 삭제하도록 수정하였습니다.