### PR TITLE
[FEAT] 비밀번호 찾기 이메일 발송, 인증 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	// H2
-//	runtimeOnly 'com.h2database:h2'
+	//runtimeOnly 'com.h2database:h2'
 
 	//AWS S3
 	implementation 'software.amazon.awssdk:s3:2.27.12'
@@ -65,6 +65,12 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
+	// Apache Commons Validator
+	implementation 'commons-validator:commons-validator:1.9.0'
+
+	// Mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail:3.2.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/tarbonicar/backend/api/member/entity/Member.java
+++ b/src/main/java/com/tarbonicar/backend/api/member/entity/Member.java
@@ -38,4 +38,8 @@ public class Member extends BaseTimeEntity {
         this.authority = authority;
     }
 
+    public void updatePassword(String newEncodedPassword) {
+        this.password = newEncodedPassword;
+    }
+
 }

--- a/src/main/java/com/tarbonicar/backend/api/passwordReset/controller/PasswordResetController.java
+++ b/src/main/java/com/tarbonicar/backend/api/passwordReset/controller/PasswordResetController.java
@@ -1,0 +1,76 @@
+package com.tarbonicar.backend.api.passwordReset.controller;
+
+import com.tarbonicar.backend.api.passwordReset.dto.PasswordResetConfirmDTO;
+import com.tarbonicar.backend.api.passwordReset.dto.PasswordResetDTO;
+import com.tarbonicar.backend.api.passwordReset.dto.PasswordResetRequestDTO;
+import com.tarbonicar.backend.api.passwordReset.service.PasswordResetService;
+import com.tarbonicar.backend.common.response.ApiResponse;
+import com.tarbonicar.backend.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "PasswordReset", description = "비밀번호 초기화 관련 API 입니다.")
+@RestController
+@RequestMapping("/api/v1/password-reset")
+@RequiredArgsConstructor
+public class PasswordResetController {
+
+    private final PasswordResetService passwordResetService;
+
+    @Operation(
+            summary = "비밀번호 초기화 요청 API",
+            description = "이메일로 비밀번호 초기화 코드를 보냅니다"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "비밀번호 초기화 링크 전송 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+    })
+    @PostMapping("/email-request")
+    public ResponseEntity<ApiResponse<Void>> requestPasswordResetCode(@RequestBody PasswordResetRequestDTO passwordResetRequestDTO) {
+
+        passwordResetService.requestPasswordResetCode(passwordResetRequestDTO);
+        return ApiResponse.success_only(SuccessStatus.SEND_PASSWORD_RESET_CODE_SUCCESS);
+    }
+
+    @Operation(
+            summary = "비밀번호 초기화 코드 검증 API",
+            description = "이메일에서 받은 코드를 검증합니다.. <br>"
+                    + "<p>"
+                    + "호출 필드 정보) <br>"
+                    + "code : 비밀번호 초기화 인증코드 <br>"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "비밀번호 초기화 인증코드 검증 성공"),
+    })
+    @PostMapping("/email-confirm")
+    public ResponseEntity<ApiResponse<Void>> resetVerifyPasswordResetCode(@RequestBody PasswordResetConfirmDTO passwordResetConfirmDTO) {
+
+        passwordResetService.resetVerifyPasswordResetCode(passwordResetConfirmDTO);
+        return ApiResponse.success_only(SuccessStatus.SEND_PASSWORD_RESET_CODE_VERIFY_SUCCESS);
+    }
+
+    @Operation(
+            summary = "비밀번호 초기화 API",
+            description = "비밀번호를 변경합니다. <br>"
+                    + "<p>"
+                    + "호출 필드 정보) <br>"
+                    + "newPassword : 새로운 비밀번호 <br>"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+    })
+    @PostMapping("/password-reset")
+    public ResponseEntity<ApiResponse<Void>> resetPassword(@Valid @RequestBody PasswordResetDTO passwordResetDTO) {
+
+        passwordResetService.resetPassword(passwordResetDTO);
+        return ApiResponse.success_only(SuccessStatus.SEND_PASSWORD_SUCCESS);
+    }
+}

--- a/src/main/java/com/tarbonicar/backend/api/passwordReset/dto/PasswordResetConfirmDTO.java
+++ b/src/main/java/com/tarbonicar/backend/api/passwordReset/dto/PasswordResetConfirmDTO.java
@@ -1,0 +1,11 @@
+package com.tarbonicar.backend.api.passwordReset.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PasswordResetConfirmDTO {
+
+    private String code;
+}

--- a/src/main/java/com/tarbonicar/backend/api/passwordReset/dto/PasswordResetDTO.java
+++ b/src/main/java/com/tarbonicar/backend/api/passwordReset/dto/PasswordResetDTO.java
@@ -1,0 +1,20 @@
+package com.tarbonicar.backend.api.passwordReset.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PasswordResetDTO {
+
+    private String code;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&]).{8,}$",
+            message = "비밀번호는 영문 대소문자, 숫자, 특수문자를 포함해 8자 이상이어야 합니다."
+    )
+    private String newPassword;
+}

--- a/src/main/java/com/tarbonicar/backend/api/passwordReset/dto/PasswordResetRequestDTO.java
+++ b/src/main/java/com/tarbonicar/backend/api/passwordReset/dto/PasswordResetRequestDTO.java
@@ -1,0 +1,11 @@
+package com.tarbonicar.backend.api.passwordReset.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PasswordResetRequestDTO {
+
+    private String email;
+}

--- a/src/main/java/com/tarbonicar/backend/api/passwordReset/entity/PasswordReset.java
+++ b/src/main/java/com/tarbonicar/backend/api/passwordReset/entity/PasswordReset.java
@@ -1,0 +1,28 @@
+package com.tarbonicar.backend.api.passwordReset.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PasswordReset {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+    private String code;
+    private LocalDateTime expirationTime;
+
+    private boolean isVerified;
+
+    public void markVerified() {
+        this.isVerified = true;
+    }
+}

--- a/src/main/java/com/tarbonicar/backend/api/passwordReset/repository/PasswordResetRepository.java
+++ b/src/main/java/com/tarbonicar/backend/api/passwordReset/repository/PasswordResetRepository.java
@@ -1,0 +1,11 @@
+package com.tarbonicar.backend.api.passwordReset.repository;
+
+import com.tarbonicar.backend.api.passwordReset.entity.PasswordReset;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PasswordResetRepository extends JpaRepository<PasswordReset, Long> {
+
+    Optional<PasswordReset> findByCode(String code);
+}

--- a/src/main/java/com/tarbonicar/backend/api/passwordReset/service/PasswordResetService.java
+++ b/src/main/java/com/tarbonicar/backend/api/passwordReset/service/PasswordResetService.java
@@ -1,0 +1,110 @@
+package com.tarbonicar.backend.api.passwordReset.service;
+
+import com.tarbonicar.backend.api.member.entity.Member;
+import com.tarbonicar.backend.api.member.repository.MemberRepository;
+import com.tarbonicar.backend.api.passwordReset.dto.PasswordResetDTO;
+import com.tarbonicar.backend.api.passwordReset.dto.PasswordResetConfirmDTO;
+import com.tarbonicar.backend.api.passwordReset.dto.PasswordResetRequestDTO;
+import com.tarbonicar.backend.api.passwordReset.entity.PasswordReset;
+import com.tarbonicar.backend.api.passwordReset.repository.PasswordResetRepository;
+import com.tarbonicar.backend.common.exception.BadRequestException;
+import com.tarbonicar.backend.common.exception.NotFoundException;
+import com.tarbonicar.backend.common.response.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordResetService {
+
+    @Value("${spring.mail.username}")
+    private String serviceEmail;
+
+    private final JavaMailSender mailSender;
+    private final MemberRepository memberRepository;
+    private final PasswordResetRepository passwordResetRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    // 인증 코드 발송
+    public void requestPasswordResetCode(PasswordResetRequestDTO dto) {
+        Member member = memberRepository.findByEmail(dto.getEmail())
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_MEMBER_EXCEPTION.getMessage()));
+
+        String resetCode = generateRandomCode();
+        LocalDateTime expirationTime = LocalDateTime.now().plusMinutes(5);
+
+        PasswordReset pr = PasswordReset.builder()
+                .email(dto.getEmail())
+                .code(resetCode)
+                .expirationTime(expirationTime)
+                .isVerified(false)
+                .build();
+        passwordResetRepository.save(pr);
+
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setFrom(String.format("타보니까 <%s>", serviceEmail));
+        msg.setTo(dto.getEmail());
+        msg.setSubject("타보니까 비밀번호 재설정 링크");
+        msg.setText("비밀번호를 재설정하려면 아래 링크를 클릭하세요:\n\n"
+                + "https://www.tarbonicar.kro.kr/reset-password-confirm?code=" + resetCode
+                + "\n\n(5분간 유효)");
+        mailSender.send(msg);
+    }
+
+    // 인증 코드 검증
+    @Transactional
+    public void resetVerifyPasswordResetCode(PasswordResetConfirmDTO dto) {
+        PasswordReset pr = passwordResetRepository.findByCode(dto.getCode())
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.INVALID_PASSWORD_RESET_CODE_EXCEPTION.getMessage()));
+
+        if (pr.getExpirationTime().isBefore(LocalDateTime.now())) {
+            throw new BadRequestException(ErrorStatus.EXPIRED_PASSWORD_RESET_CODE_EXCEPTION.getMessage());
+        }
+
+        pr.markVerified();
+        passwordResetRepository.save(pr);
+    }
+
+    // 비밀번호 초기화
+    @Transactional
+    public void resetPassword(PasswordResetDTO dto) {
+        PasswordReset pr = passwordResetRepository.findByCode(dto.getCode())
+                .orElseThrow(() -> new BadRequestException(ErrorStatus.INVALID_PASSWORD_RESET_CODE_EXCEPTION.getMessage()));
+
+        if (!pr.isVerified()) {
+            throw new BadRequestException(ErrorStatus.UNVERIFIED_PASSWORD_RESET_CODE_EXCEPTION.getMessage());
+        }
+        if (pr.getExpirationTime().isBefore(LocalDateTime.now())) {
+            throw new BadRequestException(ErrorStatus.EXPIRED_PASSWORD_RESET_CODE_EXCEPTION.getMessage());
+        }
+
+        Member member = memberRepository.findByEmail(pr.getEmail())
+                .orElseThrow(() -> new NotFoundException(ErrorStatus.NOT_FOUND_MEMBER_EXCEPTION.getMessage()));
+
+        String encoded = passwordEncoder.encode(dto.getNewPassword());
+
+        member.updatePassword(encoded);
+        memberRepository.save(member);
+
+        passwordResetRepository.delete(pr);
+    }
+
+    // 랜덤 코드 생성
+    private String generateRandomCode() {
+        SecureRandom random = new SecureRandom();
+        StringBuilder sb = new StringBuilder(6);
+        String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        for (int i = 0; i < 6; i++) {
+            sb.append(chars.charAt(random.nextInt(chars.length())));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/tarbonicar/backend/common/config/mail/MailConfig.java
+++ b/src/main/java/com/tarbonicar/backend/common/config/mail/MailConfig.java
@@ -1,0 +1,38 @@
+package com.tarbonicar.backend.common.config.mail;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+    @Value("${spring.mail.host}")
+    private String mailServerHost;
+    @Value("${spring.mail.port}")
+    private String mailServerPort;
+    @Value("${spring.mail.username}")
+    private String mailServerUsername;
+    @Value("${spring.mail.password}")
+    private String mailServerPassword;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(mailServerHost);
+        mailSender.setPort(Integer.parseInt(mailServerPort));
+
+        mailSender.setUsername(mailServerUsername);
+        mailSender.setPassword(mailServerPassword);
+
+        Properties properties = mailSender.getJavaMailProperties();
+        properties.put("mail.transport.protocol", "smtp");
+        properties.put("mail.smtp.auth", "true");
+        properties.put("mail.smtp.starttls.enable", "true");
+
+        return mailSender;
+    }
+}

--- a/src/main/java/com/tarbonicar/backend/common/config/sescurity/SecurityConfig.java
+++ b/src/main/java/com/tarbonicar/backend/common/config/sescurity/SecurityConfig.java
@@ -66,6 +66,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/category", "/api/v1/category/search/**", "/api/v1/category/**").permitAll() // 카테고리 관련 인증 허용
                         .requestMatchers("/api/v1/s3/upload-image").permitAll() // 이미지 업로드 인증 허용
                         .requestMatchers(HttpMethod.GET, "/api/v1/article", "/api/v1/article/list", "/api/v1/comment").permitAll() // 게시글, 댓글 조회 인증 허용
+                        .requestMatchers("/api/v1/password-reset/email-request", "/api/v1/password-reset/email-confirm", "/api/v1/password-reset/password-reset").permitAll() // 비밀번호 초기화 인증 허용
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/tarbonicar/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/tarbonicar/backend/common/response/ErrorStatus.java
@@ -25,6 +25,9 @@ public enum ErrorStatus {
     THIS_MEMBER_IS_NOT_WRITER_EXCEPTION(HttpStatus.BAD_REQUEST,"게시글 작성자가 아닙니다."),
     THIS_MEMBER_IS_NOT_COMMENT_WRITER_EXCEPTION(HttpStatus.BAD_REQUEST,"댓글 작성자가 아닙니다."),
     ALREADY_ADD_CARAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 등록된 차량 연식 입니다."),
+    INVALID_PASSWORD_RESET_CODE_EXCEPTION(HttpStatus.BAD_REQUEST,"올바르지 않은 인증 코드 입니다."),
+    EXPIRED_PASSWORD_RESET_CODE_EXCEPTION(HttpStatus.BAD_REQUEST,"이미 만료된 인증 코드 입니다."),
+    UNVERIFIED_PASSWORD_RESET_CODE_EXCEPTION(HttpStatus.BAD_REQUEST, "미인증 된 인증 코드 입니다."),
 
     /**
      * 401 UNAUTHORIZED

--- a/src/main/java/com/tarbonicar/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/tarbonicar/backend/common/response/SuccessStatus.java
@@ -33,6 +33,9 @@ public enum SuccessStatus {
     SEND_LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
     SEND_ARTICLE_LIKE_SUCCESS(HttpStatus.OK,"게시글 좋아요 성공"),
     CHECK_EMAIL_SUCCESS(HttpStatus.OK, "이메일 중복 확인 성공"),
+    SEND_PASSWORD_RESET_CODE_SUCCESS(HttpStatus.OK, "비밀번호 초기화 링크 전송 성공"),
+    SEND_PASSWORD_RESET_CODE_VERIFY_SUCCESS(HttpStatus.OK,"비밀번호 초기화 인증코드 검증 성공"),
+    SEND_PASSWORD_SUCCESS(HttpStatus.OK,"비밀번호 초기화 성공"),
 
     /**
      * 201


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #54

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 비밀번호 찾기 이메일 발송, 인증 로직을 구현하였습니다.